### PR TITLE
Fixes issue with loading scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lrm-mapzen",
   "version": "1.0.1",
   "description": "Support for Turn By Turn by Mapzen in Leaflet Machine",
-  "main": "src/L.Routing.Mapzen.js",
+  "main": "dist/lrm-mapzen.min.js",
   "scripts": {
     "dist": "./scripts/dist.sh",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Not all scripts are loaded with an import when npm is used. Only `L.Routing.Mapzen` would be available and not the other two objects. This commit fixes this issue by loading the distribution version of the combined scripts.
